### PR TITLE
feat: 회원의 주문을 DB에 저장하는 기능 구현

### DIFF
--- a/src/main/java/kafka/order/constant/OrderStatus.java
+++ b/src/main/java/kafka/order/constant/OrderStatus.java
@@ -1,0 +1,11 @@
+package kafka.order.constant;
+
+public enum OrderStatus {
+
+    CREATED,    // 주문 생성
+    PAID,       // 결제 완료
+    COOKING,    // 조리 중
+    DELIVERING, // 배달 중
+    DELIVERED   // 배달 완료
+
+}

--- a/src/main/java/kafka/order/entity/Order.java
+++ b/src/main/java/kafka/order/entity/Order.java
@@ -3,6 +3,8 @@ package kafka.order.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import kafka.member.entity.Member;
+import kafka.order.constant.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +36,10 @@ public class Order {
 
     @Column
     private LocalDateTime orderTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
@@ -54,6 +61,7 @@ public class Order {
         }
 
         member.decreasePoints(price);
+        this.status = OrderStatus.PAID;
     }
 
     private int calculateTotalPrice() {

--- a/src/main/java/kafka/order/entity/Order.java
+++ b/src/main/java/kafka/order/entity/Order.java
@@ -40,4 +40,9 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> items = new ArrayList<>();
 
+    public void addItem(OrderItem item) {
+        item.setOrder(this);
+        items.add(item);
+    }
+
 }

--- a/src/main/java/kafka/order/entity/Order.java
+++ b/src/main/java/kafka/order/entity/Order.java
@@ -45,4 +45,20 @@ public class Order {
         items.add(item);
     }
 
+    public void payBy(Member member) {
+        int price = calculateTotalPrice();
+
+        if (member.getPoints() < price) {
+            throw new IllegalArgumentException("[ERROR] 포인트 부족");
+        }
+
+        member.decreasePoints(price);
+    }
+
+    private int calculateTotalPrice() {
+        return items.stream()
+                .mapToInt(item -> item.getMenu().getPrice() * item.getQuantity())
+                .sum();
+    }
+
 }

--- a/src/main/java/kafka/order/entity/Order.java
+++ b/src/main/java/kafka/order/entity/Order.java
@@ -38,6 +38,7 @@ public class Order {
     private Member member;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<OrderItem> items = new ArrayList<>();
 
     public void addItem(OrderItem item) {

--- a/src/main/java/kafka/order/entity/OrderItem.java
+++ b/src/main/java/kafka/order/entity/OrderItem.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -30,6 +31,7 @@ public class OrderItem {
     @Column
     private int priceAtOrder; // 주문 당시 가격
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     private Order order;
 

--- a/src/main/java/kafka/order/repository/OrderRepository.java
+++ b/src/main/java/kafka/order/repository/OrderRepository.java
@@ -1,8 +1,8 @@
 package kafka.order.repository;
 
-import kafka.menu.entity.Menu;
+import kafka.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Menu, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long> {
 
 }

--- a/src/main/java/kafka/order/service/OrderConsumer.java
+++ b/src/main/java/kafka/order/service/OrderConsumer.java
@@ -1,6 +1,5 @@
 package kafka.order.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kafka.order.dto.OrderDTO;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +13,12 @@ import org.springframework.stereotype.Component;
 public class OrderConsumer {
 
     private final OrderService orderService;
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "order-topic", groupId = "order-group")
-    public void consume(String message) throws JsonProcessingException {
-        // TODO: 빈으로 뺴기
-        ObjectMapper mapper = new ObjectMapper();
-        OrderDTO request = mapper.readValue(message, OrderDTO.class);
-
+    public void consume(String message) {
         try {
+            OrderDTO request = objectMapper.readValue(message, OrderDTO.class);
             orderService.saveOrder(request);
         } catch (Exception e) {
             log.error("[ERROR] Kafka 메시지 처리 중 예외 발생", e);

--- a/src/main/java/kafka/order/service/OrderService.java
+++ b/src/main/java/kafka/order/service/OrderService.java
@@ -1,10 +1,15 @@
 package kafka.order.service;
 
+import java.time.LocalDateTime;
 import kafka.member.entity.Member;
 import kafka.member.repository.MemberRepository;
 import kafka.menu.entity.Menu;
 import kafka.menu.repository.MenuRepository;
 import kafka.order.dto.OrderDTO;
+import kafka.order.dto.OrderItemDTO;
+import kafka.order.entity.Order;
+import kafka.order.entity.OrderItem;
+import kafka.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class OrderService {
 
+    private final OrderRepository orderRepository;
     private final MemberRepository memberRepository;
     private final MenuRepository menuRepository;
 
@@ -21,16 +27,43 @@ public class OrderService {
         log.info("주문 접수: id={}", request.memberId());
         log.info("주문 내역: order={}", request.items());
 
-        // TODO: 실제 로직
         Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자를 찾을 수 없습니다."));
 
+        // Order 생성
+        Order order = makeOrder(member, request);
+
+        // 계산 및 차감
+        orderProcedure(member, request);
+
+    }
+
+    private Order makeOrder(Member member, OrderDTO request) {
+        // Order 객체 생성 및 저장
+        Order order = Order.builder()
+                .orderTime(LocalDateTime.now())
+                .member(member)
+                .build();
+
+        // orderItem 객체 생성 및 저장
+        for (OrderItemDTO itemDTO : request.items()) {
+            OrderItem item = OrderItem.builder()
+                    .menu(menuRepository.findById(itemDTO.menuId())
+                            .orElseThrow(() -> new IllegalArgumentException("[ERROR] 메뉴를 찾을 수 없습니다.")))
+                    .quantity(itemDTO.quantity())
+                    .build();
+            order.addItem(item);
+        }
+
+        return orderRepository.save(order);
+    }
+
+    private void orderProcedure(Member member, OrderDTO request) {
         // 총 주문 금액 계산
         int amount = request.items().stream()
                 .mapToInt(item -> {
                     Menu menu = menuRepository.findById(item.menuId())
                             .orElseThrow(() -> new IllegalArgumentException("[ERROR] 메뉴를 찾을 수 없습니다."));
-
                     return menu.getPrice() * item.quantity();
                 })
                 .sum();

--- a/src/main/java/kafka/order/service/OrderService.java
+++ b/src/main/java/kafka/order/service/OrderService.java
@@ -3,6 +3,7 @@ package kafka.order.service;
 import java.time.LocalDateTime;
 import kafka.member.entity.Member;
 import kafka.member.repository.MemberRepository;
+import kafka.menu.entity.Menu;
 import kafka.menu.repository.MenuRepository;
 import kafka.order.dto.OrderDTO;
 import kafka.order.dto.OrderItemDTO;
@@ -46,10 +47,13 @@ public class OrderService {
 
         // orderItem 객체 생성 및 저장
         for (OrderItemDTO itemDTO : request.items()) {
+            Menu menu = menuRepository.findById(itemDTO.menuId())
+                    .orElseThrow(() -> new IllegalArgumentException("[ERROR] 메뉴를 찾을 수 없습니다."));
+
             OrderItem item = OrderItem.builder()
-                    .menu(menuRepository.findById(itemDTO.menuId())
-                            .orElseThrow(() -> new IllegalArgumentException("[ERROR] 메뉴를 찾을 수 없습니다.")))
+                    .menu(menu)
                     .quantity(itemDTO.quantity())
+                    .priceAtOrder(menu.getPrice())
                     .build();
             order.addItem(item);
         }

--- a/src/main/java/kafka/order/service/OrderService.java
+++ b/src/main/java/kafka/order/service/OrderService.java
@@ -5,6 +5,7 @@ import kafka.member.entity.Member;
 import kafka.member.repository.MemberRepository;
 import kafka.menu.entity.Menu;
 import kafka.menu.repository.MenuRepository;
+import kafka.order.constant.OrderStatus;
 import kafka.order.dto.OrderDTO;
 import kafka.order.dto.OrderItemDTO;
 import kafka.order.entity.Order;
@@ -43,6 +44,7 @@ public class OrderService {
         Order order = Order.builder()
                 .orderTime(LocalDateTime.now())
                 .member(member)
+                .status(OrderStatus.CREATED)
                 .build();
 
         // orderItem 객체 생성 및 저장


### PR DESCRIPTION
## 📂 작업 요약
<!-- 작업내용을 요약해주시면 됩니다. -->
- DB에 Order를 저장함
- 주문 내역을 확인하는 등 활용할 곳이 많음 (실제 기업에서는 5년간 저장해두는 것이 의무라고도 함)
- 주문은 자신의 상태를 관리하도록 함 (이 프로젝트에서는 PAID까지만 진행 예정)


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
#7 

## ❓의문
- 근데 그렇게 많은 내용을 DB에 저장해도 되는가?
- 카프카 로그를 통해서 파일에 저장하나?
- 불러오기 되게 힘들 것 같은데?
- OrderItem을 저장하는 엔티티가 꼭 필요한가? Order에서 다 관리해도 나쁘지 않을 것 같은데?
